### PR TITLE
Correction to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Workshop Building A Simple Skill
 
-This workshop is designed to teach you how to learn the core fundamentals of building an Alexa skill.It is modular so if you know the basics you can skip to the module that interests you the most. In this repository you will find the necessary JSON and code files for each module. 
+This workshop is designed to teach you how to learn the core fundamentals of building an Alexa skill. It is modular so if you know the basics you can skip to the module that interests you the most. In this repository you will find the necessary JSON and code files for each module. 
 
 # Step-by-step Instructions
 

--- a/module-1/README.md
+++ b/module-1/README.md
@@ -2,7 +2,7 @@
 
 ## Module 1: Build A Simple Skill In 5 Minutes
 
-The files in this folder represent how Calk Time should appear at the end of this module. If you're stuck you can compare your files with these to figure out where you went wrong. You can also use these files to skip ahead.
+The files in this folder represent how Cake Time should appear at the end of this module. If you're stuck you can compare your files with these to figure out where you went wrong. You can also use these files to skip ahead.
 
 **If you are coming from the [Tutorial: Build an Engaging Alexa Skill](https://developer.amazon.com/en-US/alexa/alexa-skills-kit/get-deeper/tutorials-code-samples/build-an-engaging-alexa-skill)**: This folder maps to [Workshop Module 3](https://developer.amazon.com/en-US/alexa/alexa-skills-kit/get-deeper/tutorials-code-samples/build-an-engaging-alexa-skill/module-3)
 

--- a/module-2/README.md
+++ b/module-2/README.md
@@ -2,7 +2,7 @@
 
 ## Module 2: Collect Slots Turn-by-turn
 
-The files in this folder represent how Calk Time should appear at the end this module. If you're stuck you can compare your files with these to figure out where you went wrong. You can also use these files to skip ahead.
+The files in this folder represent how Cake Time should appear at the end this module. If you're stuck you can compare your files with these to figure out where you went wrong. You can also use these files to skip ahead.
 
 **If you are coming from the [Tutorial: Build an Engaging Alexa Skill](https://developer.amazon.com/alexa/alexa-skills-kit/get-deeper/tutorials-code-samples/build-an-engaging-alexa-skill)**: This folder maps to [Workshop Module 4](https://developer.amazon.com/en-US/alexa/alexa-skills-kit/get-deeper/tutorials-code-samples/build-an-engaging-alexa-skill/module-4)
 

--- a/module-3/README.md
+++ b/module-3/README.md
@@ -2,7 +2,7 @@
 
 ## Module 3: Add Memory To Your Skill
 
-The files in this folder represent how Calk Time should appear at the end of this module. If you're stuck you can compare your files with these to figure out where you went wrong. You can also use these files to skip ahead.
+The files in this folder represent how Cake Time should appear at the end of this module. If you're stuck you can compare your files with these to figure out where you went wrong. You can also use these files to skip ahead.
 
 
 **If you are coming from the [Tutorial: Build an Engaging Alexa Skill](https://developer.amazon.com/alexa/alexa-skills-kit/get-deeper/tutorials-code-samples/build-an-engaging-alexa-skill)**: This folder maps to [Workshop Module 5](https://developer.amazon.com/alexa/alexa-skills-kit/get-deeper/tutorials-code-samples/build-an-engaging-alexa-skill/module-5)

--- a/module-4/README.md
+++ b/module-4/README.md
@@ -2,7 +2,7 @@
 
 ## Module 4: Use The Settings API
 
-The files in this folder represent how Calk Time should appear at the end of this module. If you're stuck you can compare your files with these to figure out where you went wrong. You can also use these files to skip Module 1, 2 and 3.
+The files in this folder represent how Cake Time should appear at the end of this module. If you're stuck you can compare your files with these to figure out where you went wrong. You can also use these files to skip Module 1, 2 and 3.
 
 **If you are coming from the [Tutorial: Build an Engaging Alexa Skill](https://developer.amazon.com/alexa/alexa-skills-kit/get-deeper/tutorials-code-samples/build-an-engaging-alexa-skill)**: This folder maps to [Workshop Module 6](https://developer.amazon.com/alexa/alexa-skills-kit/get-deeper/tutorials-code-samples/build-an-engaging-alexa-skill/module-6)**
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The four module README files mention Calk instead of Cake. There is also a suggested space added to the main README to aid readability. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
